### PR TITLE
Allow different segment order and improve errors

### DIFF
--- a/undump.c
+++ b/undump.c
@@ -402,11 +402,14 @@ int main(int argc, char *argv[])
     }
 
     struct core *c = load_core(op.core_file_name);
+    if (!c) {
+        perror("failed to load core");
+        return 3;
+    }
     struct program *p = prog_read_elf(op.program_file_name);
-
-    if(!c  || !p) {
-        perror("??");
-        return 2;
+    if (!p) {
+        perror("failed to read elf");
+        return 4;
     }
 
     dump_core_data(c);


### PR DESCRIPTION
This is a very hacky way to do it, but it allows handling a different note order:
```
  Owner                Data size        Description
  CORE                 0x00000088       NT_PRPSINFO (prpsinfo structure)
  CORE                 0x00000150       NT_PRSTATUS (prstatus structure)
  CORE                 0x00000200       NT_FPREGSET (floating point registers)
```
(previously undump failed on NT_PRPSINFO)